### PR TITLE
Omit use of deprecated std::is_literal_type in a STATIC_ASSERT

### DIFF
--- a/src/carl/core/Variable.h
+++ b/src/carl/core/Variable.h
@@ -241,7 +241,6 @@ public:
 	static const Variable NO_VARIABLE;
 };
 //static_assert(std::is_trivially_copyable<Variable>::value, "Variable should be trivially copyable.");
-static_assert(std::is_literal_type<Variable>::value, "Variable should be a literal type.");
 
 } // namespace carl
 


### PR DESCRIPTION
`std::is_literal_type` is [removed in C++20](https://en.cppreference.com/w/cpp/types/is_literal_type).
There does not seem to be an obvious replacement.
I think it's fine to just omit the`STATIC_ASSERT` but feel free to disagree :)