### PR TITLE
Fixed cmake export

### DIFF
--- a/cmake/export.cmake
+++ b/cmake/export.cmake
@@ -8,6 +8,7 @@ export(TARGETS ${CARL_TARGETS} FILE "${PROJECT_BINARY_DIR}/carlTargets.cmake")
 # (this registers the build-tree with a global CMake-registry)
 if(EXPORT_TO_CMAKE)
 	message(STATUS "Registered with cmake")
+	set(CMAKE_EXPORT_PACKAGE_REGISTRY ON)
 	export(PACKAGE carl)
 endif()
 


### PR DESCRIPTION
CMake 3.15 does not export to package registry by default (see [here](https://cmake.org/cmake/help/latest/policy/CMP0090.html#policy:CMP0090)).
We fixed this in [Storm](https://github.com/moves-rwth/storm/pull/401) and now also in carl-storm.