### PR TITLE
v14.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 Changelog
 ==============
 
+## Version 14.27 (2024/02)
+- Fixed CMake support for CLN
+
 ## Version 14.26 (2023/12)
 - Interval API extended
 - Some code cleanup

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # Include own macros.
 include( carlmacros )
 
-set_version(14 26 0)
+set_version(14 27 0)
 
 set( PROJECT_FULLNAME "carl")
 set( PROJECT_DESCRIPTION "Computer ARithmetic Library")

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Set base image
 ARG BASE_IMAGE=movesrwth/storm-basesystem:latest
 FROM $BASE_IMAGE
-MAINTAINER Matthias Volk <m.volk@utwente.nl>
+MAINTAINER Matthias Volk <m.volk@tue.nl>
 
 
 # Configuration arguments


### PR DESCRIPTION
- Bump version to 14.27 which incorporates the fixed version parsing for the latest CLN version