### PR TITLE
Perform a hash_combine in getHash() of FactorizedPolynomial

### DIFF
--- a/src/carl/core/FactorizedPolynomial.h
+++ b/src/carl/core/FactorizedPolynomial.h
@@ -13,6 +13,7 @@
 #include "DivisionResult.h"
 #include "PolynomialFactorizationPair.h"
 #include "VariablesInformation.h"
+#include "carl/util/hash.h"
 
 namespace carl
 {
@@ -193,10 +194,13 @@ namespace carl
         {
             if( existsFactorization( *this ) )
             {
+                std::size_t seed = 0;
                 // Getting the hash of mCacheRef does not work because rehashing might occur.
                 // To have a consistent hash we need to compute the hash of the expanded polynomial.
                 // Note that building the polynomial can greatly increase the hashing time.
-                return std::hash<P>()(this->polynomialWithCoefficient());
+                carl::hash_combine( seed, std::hash<P>()( this->polynomial() ) );
+                carl::hash_combine( seed, std::hash<CoeffType>()( mCoefficient ) );
+                return seed;
             }
             return std::hash<CoeffType>()( mCoefficient );
         }


### PR DESCRIPTION
Previously, the `getHash` function of FactorizedPolynomial called `polynomialWithCoefficient`, which multiplies each term with the coefficient. For my applications with large FactorizedPolynomials that often get hashed, this was very slow. Changing this to hashing the polynomial and the coefficient sped up my Storm invocation (that also does a lof of other stuff) from 47s to 34s.