### PR TITLE
CI: limit trigger for push to master branch

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -4,6 +4,8 @@ name: Build Test
 
 on:
   push:
+    branches:
+      - master
   schedule:
     # run weekly
     - cron: '0 10 * * 2'


### PR DESCRIPTION
Commits to a PR currently trigger the CI twice: once for the push and once for the PR. Limiting to the master branch should prevent it.