### PR TITLE
Download ginac/cln archive instead of using git repo

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -14,8 +14,8 @@ on:
   pull_request:
 
 env:
-  # GitHub runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 jobs:
   distroTests:

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -42,7 +42,7 @@ jobs:
         run: docker exec ci bash -c "cd /opt/carl/build; ctest test --output-on-failure"
 
   minimalTests:
-    name: Minimal dependencies Tests ${{ matrix.buildType }})
+    name: Minimal dependencies Tests (${{ matrix.buildType }})
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -10,8 +10,8 @@ on:
         default: 'x.y.z'
 
 env:
-  # GitHub runners currently have two cores
-  NR_JOBS: "2"
+  # GitHub runners currently have 4 cores
+  NR_JOBS: "4"
 
 jobs:
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # Set base image
 ARG BASE_IMAGE=movesrwth/storm-basesystem:latest
 FROM $BASE_IMAGE
-MAINTAINER Matthias Volk <m.volk@tue.nl>
+LABEL org.opencontainers.image.authors="dev@stormchecker.org"
 
 
 # Configuration arguments

--- a/resources/cln.cmake
+++ b/resources/cln.cmake
@@ -2,12 +2,14 @@ string(REPLACE "." "-" CLN_TAG ${CLN_VERSION})
 
 ExternalProject_Add(
 	CLN-EP
-	#URL https://www.ginac.de/CLN/cln-${CLN_VERSION}.tar.bz2
-	GIT_REPOSITORY "git://www.ginac.de/cln.git"
-	GIT_TAG "cln_${CLN_TAG}"
+	URL https://www.ginac.de/CLN/cln-${CLN_VERSION}.tar.bz2
+	#GIT_REPOSITORY "git://www.ginac.de/cln.git"
+	#GIT_TAG "cln_${CLN_TAG}"
 	DOWNLOAD_NO_PROGRESS 1
-	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
-	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${CMAKE_BUILD_TYPE} --target cln
+	CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+	#CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
+	#BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${CMAKE_BUILD_TYPE} --target cln
+	BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
 	LOG_INSTALL 1
 	BUILD_BYPRODUCTS ${INSTALL_DIR}/lib/libcln${DYNAMIC_EXT} ${INSTALL_DIR}/lib/libcln${STATIC_EXT}
 )

--- a/resources/cln.cmake
+++ b/resources/cln.cmake
@@ -2,14 +2,16 @@ string(REPLACE "." "-" CLN_TAG ${CLN_VERSION})
 
 ExternalProject_Add(
 	CLN-EP
+	# Use archive instead of Git repository because availability of Git repo was not stable enough
 	URL https://www.ginac.de/CLN/cln-${CLN_VERSION}.tar.bz2
 	#GIT_REPOSITORY "git://www.ginac.de/cln.git"
 	#GIT_TAG "cln_${CLN_TAG}"
 	DOWNLOAD_NO_PROGRESS 1
+	# Archive only comes with autotools instead of CMake
 	CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-static
+	BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
 	#CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 	#BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${CMAKE_BUILD_TYPE} --target cln
-	BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}
 	LOG_INSTALL 1
 	BUILD_BYPRODUCTS ${INSTALL_DIR}/lib/libcln${DYNAMIC_EXT} ${INSTALL_DIR}/lib/libcln${STATIC_EXT}
 )

--- a/resources/cln.cmake
+++ b/resources/cln.cmake
@@ -6,7 +6,7 @@ ExternalProject_Add(
 	#GIT_REPOSITORY "git://www.ginac.de/cln.git"
 	#GIT_TAG "cln_${CLN_TAG}"
 	DOWNLOAD_NO_PROGRESS 1
-	CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
+	CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR> --disable-static
 	#CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 	#BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${CMAKE_BUILD_TYPE} --target cln
 	BUILD_COMMAND ${CMAKE_MAKE_PROGRAM}

--- a/resources/ginac.cmake
+++ b/resources/ginac.cmake
@@ -7,6 +7,7 @@ string(REPLACE "." "-" GINAC_TAG ${GINAC_VERSION})
 
 ExternalProject_Add(
 	GiNaC-EP
+	# Use archive instead of Git repository because availability of Git repo was not stable enough
 	URL https://www.ginac.de/ginac-${GINAC_VERSION}.tar.bz2
 	#GIT_REPOSITORY "git://www.ginac.de/ginac.git"
 	#GIT_TAG "release_${GINAC_TAG}"

--- a/resources/ginac.cmake
+++ b/resources/ginac.cmake
@@ -7,9 +7,9 @@ string(REPLACE "." "-" GINAC_TAG ${GINAC_VERSION})
 
 ExternalProject_Add(
 	GiNaC-EP
-	#URL https://www.ginac.de/ginac-${GINAC_VERSION}.tar.bz2
-	GIT_REPOSITORY "git://www.ginac.de/ginac.git"
-	GIT_TAG "release_${GINAC_TAG}"
+	URL https://www.ginac.de/ginac-${GINAC_VERSION}.tar.bz2
+	#GIT_REPOSITORY "git://www.ginac.de/ginac.git"
+	#GIT_TAG "release_${GINAC_TAG}"
 	DOWNLOAD_NO_PROGRESS 1
 	CMAKE_ARGS -DCMAKE_INSTALL_PREFIX=<INSTALL_DIR>
 	BUILD_COMMAND ${CMAKE_COMMAND} --build <BINARY_DIR> --config ${CMAKE_BUILD_TYPE} --target ginac


### PR DESCRIPTION
The git repositories for Ginac and CLN cannot be cloned since 2 weeks and this is the second time there is an issue with the repo. This PR fixes the issue by using the direct download instead.
Disadvantages are:
- only the latest version is supported for download which means a timely update is required for a new version, and
- the zipped archive of CLN has no CMake support