### PR TITLE
remove header inclusion that includes a deprecated boost header

### DIFF
--- a/src/carl/formula/Formula.h
+++ b/src/carl/formula/Formula.h
@@ -13,7 +13,6 @@
 #include <functional>
 #include <string>
 #include <set>
-#include <boost/dynamic_bitset.hpp>
 #include "Condition.h"
 #include "Constraint.h"
 #include "uninterpreted/UEquality.h"


### PR DESCRIPTION
This header caused a warning in the storm compilation process and seems not necessary. 