### PR TITLE
Removed std::move before return as fix for copy ellision warning

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ["debian-12", "ubuntu-22.04", "ubuntu-24.04", "minimal_dependencies"]
+        distro: ["debian-12", "ubuntu-24.04", "debian-13", "minimal_dependencies"]
         build_type: ["Debug", "Release"]
     steps:
       - name: Git clone

--- a/src/carl/core/FactorizedPolynomial.h
+++ b/src/carl/core/FactorizedPolynomial.h
@@ -462,7 +462,7 @@ namespace carl
 
         UnivariatePolynomial<CoeffType> toUnivariatePolynomial() const
         {
-            return std::move(polynomial().toUnivariatePolynomial() *= mCoefficient); // In this case it makes sense to expand the polynomial.
+            return polynomial().toUnivariatePolynomial() *= mCoefficient; // In this case it makes sense to expand the polynomial.
         }
 
         UnivariatePolynomial<FactorizedPolynomial<P>> toUnivariatePolynomial( Variable _var ) const;
@@ -953,7 +953,7 @@ namespace carl
 	template <typename P>
 	inline FactorizedPolynomial<P> operator+(const typename FactorizedPolynomial<P>::CoeffType& _lhs, const FactorizedPolynomial<P>& _rhs)
     {
-		return std::move(_rhs + _lhs);
+		return _rhs + _lhs;
 	}
 	/// @}
 	
@@ -974,7 +974,7 @@ namespace carl
 	template <typename P>
 	inline FactorizedPolynomial<P> operator-(const typename FactorizedPolynomial<P>::CoeffType& _lhs, const FactorizedPolynomial<P>& _rhs)
     {
-		return std::move( -_rhs + _lhs );
+		return -_rhs + _lhs;
 	}
 	/// @}
 	
@@ -995,7 +995,7 @@ namespace carl
 	template <typename P>
 	inline FactorizedPolynomial<P> operator*(const typename FactorizedPolynomial<P>::CoeffType& _lhs, const FactorizedPolynomial<P>& _rhs)
     {
-		return std::move(_rhs * _lhs);
+		return _rhs * _lhs;
 	}
     
 	template <typename P>

--- a/src/carl/core/FactorizedPolynomial.tpp
+++ b/src/carl/core/FactorizedPolynomial.tpp
@@ -613,12 +613,12 @@ namespace carl
             if (subResult.isConstant()) {
                 FactorizedPolynomial<P> result(subResult.constantPart() * mCoefficient);
                 assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutionsAsP));
-                return std::move(result);
+                return result;
             } else {
                 FactorizedPolynomial<P> result(std::move(subResult), mpCache);
                 result *= mCoefficient;
                 assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutionsAsP));
-                return std::move(result);
+                return result;
             }
         } else {
             CoeffType resultCoeff = mCoefficient;
@@ -638,7 +638,7 @@ namespace carl
             }
             FactorizedPolynomial<P> result(std::move(resultFactorization), resultCoeff, mpCache);
             assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutionsAsP));
-            return std::move(result);
+            return result;
         }
     }
 
@@ -656,12 +656,12 @@ namespace carl
             if (subResult.isConstant()) {
                 FactorizedPolynomial<P> result(subResult.constantPart() * mCoefficient);
                 assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutions));
-                return std::move(result);
+                return result;
             } else {
                 FactorizedPolynomial<P> result(std::move(subResult), mpCache);
                 result *= mCoefficient;
                 assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutions));
-                return std::move(result);
+                return result;
             }
         } else {
             CoeffType resultCoeff = mCoefficient;
@@ -680,7 +680,7 @@ namespace carl
             }
             FactorizedPolynomial<P> result(std::move(resultFactorization), resultCoeff, mpCache);
             assert(computePolynomial(result) == computePolynomial(*this).substitute(substitutions));
-            return std::move(result);
+            return result;
         }
     }
 
@@ -756,7 +756,7 @@ namespace carl
     {
         FactorizedPolynomial<P> result( *this );
         result /= _divisor;
-        return std::move( result );
+        return result;
     }
     
     template<typename P>
@@ -836,8 +836,9 @@ namespace carl
     template<typename P>
     P computePolynomial( const FactorizedPolynomial<P>& _fpoly )
     {
-        if( _fpoly.pCache() == nullptr )
-            return std::move( P( _fpoly.coefficient() ) );
+        if( _fpoly.pCache() == nullptr ) {
+            return P( _fpoly.coefficient() );
+        }
         P result = computePolynomial( _fpoly.content() );
         result *= _fpoly.coefficient();
         return result;
@@ -852,7 +853,7 @@ namespace carl
             result *= carl::pow( factor->first.coefficient(), factor->second );
             factor->first.mCoefficient = 1;
         }
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -861,7 +862,7 @@ namespace carl
         FactorizedPolynomial<P> result( *this );
         result.mCoefficient *= Coeff<P>( -1 );
         assert( (-computePolynomial( *this )) == computePolynomial( result ) );
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -878,20 +879,20 @@ namespace carl
             {
                 FactorizedPolynomial<P> result( _rhs.polynomial() * _rhs.coefficient() + _lhs.coefficient(), _rhs.pCache() );
                 assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-                return std::move( result );
+                return result;
             }
             else
             {
                 FactorizedPolynomial<P> result( _lhs.coefficient() + _rhs.coefficient() );
                 assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-                return std::move( result );
+                return result;
             }
         }
         else if( !existsFactorization( _rhs ) )
         {
             FactorizedPolynomial<P> result( _lhs.polynomial() * _lhs.coefficient() + _rhs.coefficient(), _lhs.pCache() );
             assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
 
         Coeff<P> coefficientCommon = Coeff<P>(carl::gcd( carl::getNum( _lhs.coefficient() ), carl::getNum( _rhs.coefficient() ) )) /
@@ -903,7 +904,7 @@ namespace carl
         {
             FactorizedPolynomial<P> result;
             assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
 
         Factorization<P> factorizationRestA, factorizationRestB;
@@ -931,7 +932,7 @@ namespace carl
         {
             FactorizedPolynomial<P> result;
             assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
         else
         {
@@ -947,14 +948,15 @@ namespace carl
         }
         FactorizedPolynomial<P> result( std::move( resultFactorization ), coefficientCommon, FactorizedPolynomial<P>::chooseCache( _lhs.pCache(), _rhs.pCache() ) );
         assert( computePolynomial( _lhs ) + computePolynomial( _rhs ) == computePolynomial( result ) );
-        return std::move( result );
+        return result;
     }
     
     template<typename P>
     FactorizedPolynomial<P> operator+( const FactorizedPolynomial<P>& _fpoly, const typename FactorizedPolynomial<P>::CoeffType& _coef )
     {
         FactorizedPolynomial<P> result( _fpoly );
-        return std::move( result += _coef ); 
+        result += _coef;
+        return result;
     }
 
     template<typename P>
@@ -975,7 +977,8 @@ namespace carl
     FactorizedPolynomial<P> operator-( const FactorizedPolynomial<P>& _fpoly, const typename FactorizedPolynomial<P>::CoeffType& _coef )
     {
         FactorizedPolynomial<P> result( _fpoly );
-        return std::move( result -= _coef ); 
+        result -= _coef;
+        return result;
     }
 
     template<typename P>
@@ -1002,13 +1005,13 @@ namespace carl
         {
             FactorizedPolynomial<P> result = _lhs + FactorizedPolynomial<P>( std::move( Factorization<P>( _rhs.factorization() ) ), coefficient, _rhs.pCache() );
             assert( computePolynomial( _lhs ) - computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
         else
         {
             FactorizedPolynomial<P> result = _lhs + FactorizedPolynomial<P>( coefficient );
             assert( computePolynomial( _lhs ) - computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
     }
     
@@ -1019,12 +1022,12 @@ namespace carl
         {
             FactorizedPolynomial<P> result;
             assert( computePolynomial( _fpoly ) * _coeff == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
         FactorizedPolynomial<P> result( _fpoly );
         result.mCoefficient *= _coeff;
         assert( computePolynomial( _fpoly ) * _coeff == computePolynomial( result ) );
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -1038,7 +1041,7 @@ namespace carl
         {
             FactorizedPolynomial<P> result;
             assert( computePolynomial( _lhs ) * computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
 
         if( !existsFactorization( _rhs ) )
@@ -1046,14 +1049,14 @@ namespace carl
             FactorizedPolynomial<P> result( _lhs );
             result.mCoefficient *= _rhs.mCoefficient;
             assert( computePolynomial( _lhs ) * computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
         else if( !existsFactorization( _lhs ) )
         {
             FactorizedPolynomial<P> result( _rhs );
             result.mCoefficient *= _lhs.mCoefficient;
             assert( computePolynomial( _lhs ) * computePolynomial( _rhs ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
 
         Factorization<P> resultFactorization;
@@ -1096,7 +1099,7 @@ namespace carl
         coefficientResult *= distributeCoefficients( resultFactorization );
         FactorizedPolynomial<P> result( std::move( resultFactorization ), coefficientResult, FactorizedPolynomial<P>::chooseCache( _lhs.pCache(), _rhs.pCache() ) );
         assert( computePolynomial( _lhs ) * computePolynomial( _rhs ) == computePolynomial( result ) );
-        return std::move( result );
+        return result;
     }
     
     template<typename P>
@@ -1147,11 +1150,11 @@ namespace carl
         {
             FactorizedPolynomial<P> result;
             assert( computePolynomial( *this ).quotient( computePolynomial( _fdivisor ) ) == computePolynomial( result ) );
-            return std::move( result );
+            return result;
         }
         FactorizedPolynomial<P> result = lazyDiv( *this, _fdivisor ).first;
         assert( computePolynomial( *this ).quotient( computePolynomial( _fdivisor ) ) == computePolynomial( result ) );
-        return std::move( result );
+        return result;
     }
     
     template<typename P>
@@ -1196,15 +1199,16 @@ namespace carl
     FactorizedPolynomial<P> quotient( const FactorizedPolynomial<P>& _fpolyA, const FactorizedPolynomial<P>& _fpolyB )
     {
         assert( !_fpolyB.isZero() );
-        return std::move( _fpolyA.quotient( _fpolyB ) );
+        return _fpolyA.quotient( _fpolyB );
     }
 
     template<typename P>
     std::pair<FactorizedPolynomial<P>,FactorizedPolynomial<P>> lazyDiv( const FactorizedPolynomial<P>& _fpolyA, const FactorizedPolynomial<P>& _fpolyB )
     {
         assert( !_fpolyB.isZero() );
-        if( _fpolyA.isZero() )
-            return std::move( std::make_pair( FactorizedPolynomial<P>(), FactorizedPolynomial<P>( Coeff<P>( 1 ) ) ) );
+        if( _fpolyA.isZero() ) {
+            return std::make_pair( FactorizedPolynomial<P>(), FactorizedPolynomial<P>( Coeff<P>( 1 ) ) );
+        }
         ASSERT_CACHE_EQUAL( _fpolyA.pCache(), _fpolyB.pCache() );
         _fpolyA.strengthenActivity();
         _fpolyB.strengthenActivity();
@@ -1216,7 +1220,7 @@ namespace carl
             fPolyASimplified.mCoefficient /= _fpolyB.mCoefficient;
             auto result = std::make_pair( fPolyASimplified, FactorizedPolynomial<P>( Coeff<P>( 1 ) ) );
             assert( computePolynomial( result.first ) * computePolynomial( _fpolyB ) == computePolynomial( result.second ) * computePolynomial( _fpolyA ) );
-            return std::move( result );
+            return result;
         }
         else if( !existsFactorization( _fpolyA ) )
         {
@@ -1228,7 +1232,7 @@ namespace carl
             fPolyBSimplified.mCoefficient = Coeff<P>( 1 );
             auto result = std::make_pair( fPolyASimplified, fPolyBSimplified );
             assert( computePolynomial( result.first ) * computePolynomial( _fpolyB ) == computePolynomial( result.second ) * computePolynomial( _fpolyA ) );
-            return std::move( result );
+            return result;
         }
         Factorization<P> resultFactorizationA;
         Factorization<P> resultFactorizationB;
@@ -1294,7 +1298,7 @@ namespace carl
             result.mCoefficient = coefficientLCM;
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-            return std::move( result );
+            return result;
         }
         else if( !existsFactorization( _fpolyA ) )
         {
@@ -1302,7 +1306,7 @@ namespace carl
             result.mCoefficient = coefficientLCM;
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-            return std::move( result );
+            return result;
         }
         CARL_LOG_DEBUG( "carl.core.factorizedpolynomial", "Compute LCM of " << _fpolyA << " and " << _fpolyB );
 
@@ -1332,7 +1336,7 @@ namespace carl
         CARL_LOG_DEBUG( "carl.core.factorizedpolynomial", "LCM of " << _fpolyA << " and " << _fpolyB << ": " << result);
         assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
         assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -1352,7 +1356,7 @@ namespace carl
             result.mCoefficient = coefficientLCM;
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-            return std::move( result );
+            return result;
         }
         else if( !existsFactorization( _fpolyA ) )
         {
@@ -1360,7 +1364,7 @@ namespace carl
             result.mCoefficient = coefficientLCM;
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
             assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-            return std::move( result );
+            return result;
         }
         
         Factorization<P> cmFactorization;
@@ -1400,7 +1404,7 @@ namespace carl
         FactorizedPolynomial<P> result( std::move( cmFactorization ), coefficientLCM, FactorizedPolynomial<P>::chooseCache( _fpolyA.pCache(), _fpolyB.pCache() ) );
         assert( computePolynomial( result ).remainder( computePolynomial( _fpolyA ) ).isZero() );
         assert( computePolynomial( result ).remainder( computePolynomial( _fpolyB ) ).isZero() );
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -1418,7 +1422,7 @@ namespace carl
             FactorizedPolynomial<P> result( coefficientCommon );
             assert( computePolynomial( _fpolyA ).remainder( computePolynomial( result ) ).isZero() );
             assert( computePolynomial( _fpolyB ).remainder( computePolynomial( result ) ).isZero() );
-            return std::move( result );
+            return result;
         }
         
         Factorization<P> cdFactorization;
@@ -1442,7 +1446,7 @@ namespace carl
         FactorizedPolynomial<P> result( std::move( cdFactorization ), coefficientCommon, FactorizedPolynomial<P>::chooseCache( _fpolyA.pCache(), _fpolyB.pCache() ) );
         assert( computePolynomial( _fpolyA ).remainder( computePolynomial( result ) ).isZero() );
         assert( computePolynomial( _fpolyB ).remainder( computePolynomial( result ) ).isZero() );
-        return std::move( result );
+        return result;
     }
 
     template<typename P>
@@ -1498,7 +1502,7 @@ namespace carl
         }
         assert( computePolynomial( _fFactorizationA ) == computePolynomial( resultFactorization ) * computePolynomial( _fFactorizationRestA ) );
         assert( computePolynomial( _fFactorizationB ) == computePolynomial( resultFactorization ) * computePolynomial( _fFactorizationRestB ) );
-        return std::move( resultFactorization );
+        return resultFactorization;
     }
 
     template<typename P>
@@ -1506,7 +1510,7 @@ namespace carl
     {
         assert( !_fpolyA.isZero() && !_fpolyB.isZero() );
         FactorizedPolynomial<P> restA, restB;
-        return std::move( gcd( _fpolyA, _fpolyB, restA, restB ) );
+        return gcd( _fpolyA, _fpolyB, restA, restB );
     }
 
     template<typename P>
@@ -1531,7 +1535,7 @@ namespace carl
                 FactorizedPolynomial<P> result( coefficientCommon );
                 assert( computePolynomial( _fpolyA ) == computePolynomial( result ) * computePolynomial( _fpolyRestA ) );
                 assert( computePolynomial( _fpolyB ) == computePolynomial( result ) * computePolynomial( _fpolyRestB ) );
-                return std::move( result );
+                return result;
             }
             else
             {
@@ -1540,7 +1544,7 @@ namespace carl
                 FactorizedPolynomial<P> result( coefficientCommon );
                 assert( computePolynomial( _fpolyA ) == computePolynomial( result ) * computePolynomial( _fpolyRestA ) );
                 assert( computePolynomial( _fpolyB ) == computePolynomial( result ) * computePolynomial( _fpolyRestB ) );
-                return std::move( result );
+                return result;
             }
         }
         else if ( !existsFactorization( _fpolyB ) )
@@ -1550,7 +1554,7 @@ namespace carl
             FactorizedPolynomial<P> result( coefficientCommon );
             assert( computePolynomial( _fpolyA ) == computePolynomial( result ) * computePolynomial( _fpolyRestA ) );
             assert( computePolynomial( _fpolyB ) == computePolynomial( result ) * computePolynomial( _fpolyRestB ) );
-            return std::move( result );
+            return result;
         }
 
         //Both polynomials are not constant
@@ -1576,7 +1580,7 @@ namespace carl
         FactorizedPolynomial<P> result( std::move( gcdFactorization ), coefficientCommon, _fpolyA.pCache() );
         assert( computePolynomial( _fpolyA ) == computePolynomial( result ) * computePolynomial( _fpolyRestA ) );
         assert( computePolynomial( _fpolyB ) == computePolynomial( result ) * computePolynomial( _fpolyRestB ) );
-        return std::move( result );
+        return result;
     }
     
     template<typename P>

--- a/src/carl/core/UnivariatePolynomial.tpp
+++ b/src/carl/core/UnivariatePolynomial.tpp
@@ -1756,11 +1756,11 @@ UnivariatePolynomial<C> operator*(const UnivariatePolynomial<C>& lhs, const Univ
 
 template<typename C>
 UnivariatePolynomial<C> operator*(const UnivariatePolynomial<C>& lhs, Variable rhs) {
-	return std::move(UnivariatePolynomial<C>(lhs) *= rhs);
+	return UnivariatePolynomial<C>(lhs) *= rhs;
 }
 template<typename C>
 UnivariatePolynomial<C> operator*(Variable lhs, const UnivariatePolynomial<C>& rhs) {
-	return std::move(UnivariatePolynomial<C>(rhs) *= lhs);
+	return UnivariatePolynomial<C>(rhs) *= lhs;
 }
 
 template<typename C>

--- a/src/carl/formula/parser/DIMACSImporter.h
+++ b/src/carl/formula/parser/DIMACSImporter.h
@@ -41,7 +41,7 @@ private:
 			if (id > 0) vars.emplace_back(v);
 			else vars.emplace_back(NOT, v);
 		}
-		return std::move(Formula<Pol>(OR, std::move(vars)));
+		return Formula<Pol>(OR, std::move(vars));
 	}
 	
 	Formula<Pol> parseFormula() {

--- a/src/carl/interval/IntervalEvaluation.h
+++ b/src/carl/interval/IntervalEvaluation.h
@@ -125,7 +125,7 @@ inline Interval<Numeric> IntervalEvaluation::evaluate(const FactorizedPolynomial
                 return factorEvaluated;
             result *= factorEvaluated.pow( factor.second );
         }
-        return std::move( result );
+        return result;
     }
 }
 


### PR DESCRIPTION
There were some warnings that "moving a temporary object prevents copy elision".