### PR TITLE
CI workflow for new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release new version
 # Triggered by new a release on Github
-# Deploys Docker containers and updates stable branch
+# - deploys Docker containers
+# - updates stable branch
+# - updates carl-storm version in Storm
+
+# Needs personal access token CI_token with permissions 'pull-requests' and 'workflows'
 
 on:
   release:
@@ -8,12 +12,14 @@ on:
 
 jobs:
   deploy_docker:
+    # Create Docker images for tag
     uses: ./.github/workflows/release_docker.yml
     with:
       # Use the tag from the release
       tag: ${{ github.event.release.tag_name }}
 
   update_stable:
+    # Update stable branch
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -33,7 +39,17 @@ jobs:
           git push origin stable
 
   deploy_docker_stable:
+    # Create Docker images for stable branch
     needs: update_stable
     uses: ./.github/workflows/release_docker.yml
     with:
       tag: stable
+
+  update_storm:
+    # Trigger generation of PR in Storm which updates the carl-storm version
+    needs: [deploy_docker, deploy_docker_stable]
+    uses: moves-rwth/storm/.github/workflows/update_carl.yml@master
+    with:
+      carl_version: ${{ github.event.release.tag_name }}
+    secrets:
+      personal_access_token: ${{ secrets.CI_token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,39 @@
+name: Release new version
+# Triggered by new a release on Github
+# Deploys Docker containers and updates stable branch
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy_docker:
+    uses: ./.github/workflows/release_docker.yml
+    with:
+      # Use the tag from the release
+      tag: ${{ github.event.release.tag_name }}
+
+  update_stable:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Git clone
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          fetch-depth: 0
+      - name: Rebase
+        run: |
+          git config user.name 'Stormchecker bot'
+          git config user.email 'dev@stormchecker.org'
+          git fetch origin stable
+          git checkout stable
+          git rebase ${{ github.event.release.tag_name }}
+          git push origin stable
+
+  deploy_docker_stable:
+    needs: update_stable
+    uses: ./.github/workflows/release_docker.yml
+    with:
+      tag: stable

--- a/.github/workflows/release_docker.yml
+++ b/.github/workflows/release_docker.yml
@@ -4,12 +4,21 @@ name: Release Docker
 # https://docs.docker.com/build/ci/github-actions/multi-platform/#distribute-build-across-multiple-runners
 
 on:
+  # needed to reuse the workflow from another one
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Docker tag (e.g. 1.1.0 or stable)'
+        required: true
+        type: string
+        default: 'x.y.z'
   # needed to trigger the workflow manually
   workflow_dispatch:
     inputs:
       tag:
         description: 'Docker tag (e.g. 1.1.0 or stable)'
         required: true
+        type: string
         default: 'x.y.z'
 
 env:
@@ -24,12 +33,12 @@ jobs:
     strategy:
       matrix:
         image:
-          - {tag: "${{ github.event.inputs.tag }}-debug",
+          - {tag: "${{ inputs.tag }}-debug",
              baseImg: "movesrwth/storm-basesystem:latest",
              file: "Dockerfile",
              buildType: "Debug"
             }
-          - {tag: "${{ github.event.inputs.tag }}",
+          - {tag: "${{ inputs.tag }}",
              baseImg: "movesrwth/storm-basesystem:latest",
              file: "Dockerfile",
              buildType: "Release"
@@ -40,6 +49,8 @@ jobs:
     steps:
       - name: Git clone
         uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag }}
       - name: Prepare
         # Sanitize platform name
         run: |
@@ -96,8 +107,8 @@ jobs:
       matrix:
         image:
           # Must be the same as above
-          - {tag: "${{ github.event.inputs.tag }}-debug"}
-          - {tag: "${{ github.event.inputs.tag }}"}
+          - {tag: "${{ inputs.tag }}-debug"}
+          - {tag: "${{ inputs.tag }}"}
     steps:
       - name: Download digests
         uses: actions/download-artifact@v5

--- a/doc/checklist_new_release.md
+++ b/doc/checklist_new_release.md
@@ -1,44 +1,29 @@
 The following steps should be performed before releasing a new carl-storm version.
 
 1. Update `CHANGELOG.md`:
-   * To get all the commits from an author since the last tag execute:
-   ```console
-   git log last_tag..HEAD --author "author_name"
-   ```
    * Set release month
+   * Set major changes.
+     Use the [automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).
+     Alternatively, get all the commits since the `last_tag` by executing:
+     ```console
+     git log last_tag..HEAD
+     ```
 
-2. Check that carl builds without errors and all tests are successful:
-   * [Github Actions](https://github.com/moves-rwth/carl-storm/actions/) should run successfully.
+2. Check that carl-storm [CI](https://github.com/moves-rwth/carl-storm/actions/) builds without errors and all tests are successful.
 
-3. Set new carl version:
-   * Set new version in `CMakeLists.txt`
+3. Set new carl-storm version in `CMakeLists.txt`.
 
-4. Set new tag in Git (assuming that the new version is X.Y.Z and that the remote "origin" is the github repo).
-   Use the flag `-s` to sign the tag.
+4. (The tag can also automatically be set in the next step when creating the release on Github.)
+   Set the new tag in Git, use the flag `-s` to sign the tag.
    ```console
-   git tag -a X.Y.Z -m "Carl version X.Y.Z" -s
-   git push origin X.Y.Z
+   git tag -a X.Y -m "Carl version X.Y" -s
+   git push origin X.Y
    ```
    The new tag should now be visible on [GitHub](https://github.com/moves-rwth/carl-storm/tags).
 
-5. Use the [CI](https://github.com/moves-rwth/carl-storm/actions/workflows/release_docker.yml) on the tag, provide the version `X.Y.Z` as tag and automatically create the [Docker containers](https://hub.docker.com/r/movesrwth/carl-storm) for the new version.
+5. [Add new release](https://github.com/moves-rwth/carl-storm/releases/new) on GitHub.
+   Finishing the release automatically triggers a CI workflow which also
+   * updates the `stable` branch
+   * creates new Docker containers for both the tag and `stable` branch
 
-6. [Add new release](https://github.com/moves-rwth/carl-storm/releases/new) in GitHub.
-
-7. Update `stable` branch:
-
-   ```console
-   git checkout stable
-   git rebase master
-   git push origin stable
-   ```
-   Note: Rebasing might fail if `stable` is ahead of `master` (e.g. because of merge commits). In this case we can do:
-    ```console
-   git checkout stable
-   git reset --hard master
-   git push --force origin stable
-   ```
-
-8. Use the [CI](https://github.com/moves-rwth/carl-storm/actions/workflows/release_docker.yml) on the `stable` branch, provide the tag 'stable' and automatically create the [Docker containers](https://hub.docker.com/r/movesrwth/carl-storm).
-
-9. Use the [CI of docker-storm](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) to update the Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies).
+6. Use the [CI of docker-storm](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) to update the Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies).

--- a/doc/checklist_new_release.md
+++ b/doc/checklist_new_release.md
@@ -22,8 +22,8 @@ The following steps should be performed before releasing a new carl-storm versio
    The new tag should now be visible on [GitHub](https://github.com/moves-rwth/carl-storm/tags).
 
 5. [Add new release](https://github.com/moves-rwth/carl-storm/releases/new) on GitHub.
+   Create a new tag or use the tag created in the previous step.
    Finishing the release automatically triggers a CI workflow which also
    * updates the `stable` branch
    * creates new Docker containers for both the tag and `stable` branch
-
-6. Use the [CI of docker-storm](https://github.com/moves-rwth/docker-storm/actions/workflows/dependencies.yml) to update the Docker images for [storm-dependencies](https://hub.docker.com/r/movesrwth/storm-dependencies).
+   * triggers a PR in Storm to update the carl-storm version


### PR DESCRIPTION
The CI workflow is triggered for each new release and automatically performs the following:
- create a Docker container for the corresponding tag
- update the `stable` branch
- create a Docker container for the `stable` branch