### PR TITLE
Properly disable usage of CLN and Ginac

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -69,7 +69,7 @@ jobs:
           docker build -t movesrwth/carl-storm:ci . \
             --build-arg BASE_IMAGE=movesrwth/storm-basesystem:${{ matrix.distro }} \
             --build-arg build_type="${{ matrix.build_type }}" \
-            --build-arg cmake_args="-DCARL_WARNING_AS_ERROR=ON" \
+            --build-arg cmake_args="-DCARL_WARNING_AS_ERROR=ON -DALLOW_SHIPPED_CLN=OFF -DALLOW_SHIPPED_GINAC=OFF" \
             --build-arg no_threads=${NR_JOBS}
       - name: Run Docker
         run: docker run -d -it --name ci movesrwth/carl-storm:ci

--- a/resources/resources.cmake
+++ b/resources/resources.cmake
@@ -109,6 +109,7 @@ if(USE_CLN_NUMBERS)
 else()
 	message(STATUS "carl - CLN is disabled")
 endif()
+set(USE_CLN_NUMBERS ${HAVE_CLN})
 
 
 ##### CoCoALib
@@ -148,6 +149,7 @@ if(USE_GINAC AND HAVE_CLN)
 else()
 	message(STATUS "carl - GiNaC is disabled")
 endif()
+set(USE_GINAC ${HAVE_GINAC})
 
 ##### Threads
 set(CMAKE_THREAD_PREFER_PTHREAD TRUE)


### PR DESCRIPTION
Interesting story:
after the Docker image minimal-dependencies switched from using libboost-dev instead of libboost-dev-all, the CI was suddenly failing. Apparently, libboost-dev-all also installed Python which was now missing. But building Ginac from scratch requires Python.
My "solution" for now is to disable shipped Ginac and CLN for the CI workflow. This is also in line with Storm where we also do not want to manually build Ginac and CLN.

Another issue then appeared because `USE_CLN_NUMBERS` was still set even though it could not be found. I also overwrite this now if CLN/Ginac cannot be found.