### PR TITLE
Workaround for gtest issue on Clang 21

### DIFF
--- a/resources/gtest.cmake
+++ b/resources/gtest.cmake
@@ -1,5 +1,4 @@
 include(FetchContent)
-
 FetchContent_Declare(
 	googletest
 	# Use commit with workaround for char conversion warning, being recognized by Clang 21+.

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -2,7 +2,6 @@
 add_custom_target(all-tests)
 
 add_library(TestCommon STATIC Common.cpp)
-
 target_link_libraries(TestCommon lib_carl ${GTEST_LIBRARIES})
 add_dependencies(TestCommon carl_resources lib_carl GTest::gtest_main)
 


### PR DESCRIPTION
Gtest with Clang 21 outputs the following warning:
```
In file included from /opt/carl/build/_deps/googletest-src/googletest/include/gtest/gtest-matchers.h:49:
/opt/carl/build/_deps/googletest-src/googletest/include/gtest/gtest-printers.h:528:35: error: implicit conversion from 'char8_t' to 'char32_t' may change the meaning of the represented code unit [-Werror,-Wcharacter-conversion]
  528 |   PrintTo(ImplicitCast_<char32_t>(c), os);
      |           ~~~~~~~~~~~~~           ^
1 error generated.
```

It is a known [issue](https://github.com/google/googletest/issues/4762) and we use commit [fa8438a](https://github.com/google/googletest/commit/fa8438ae6b70c57010177de47a9f13d7041a6328) with a workaround.