### PR TITLE
Updated Dockerfile for Alpine

### DIFF
--- a/.github/workflows/Dockerfile.alpine
+++ b/.github/workflows/Dockerfile.alpine
@@ -6,7 +6,7 @@
 # --build-arg BASE_IMAGE=<new_base_image>
 
 # Set base image
-ARG BASE_IMAGE=alpine:latest
+ARG BASE_IMAGE=alpine:edge
 FROM $BASE_IMAGE
 LABEL org.opencontainers.image.authors="dev@stormchecker.org"
 
@@ -30,8 +30,6 @@ ARG packages=""
 
 # Install dependencies
 ######################
-RUN echo "@testing https://dl-cdn.alpinelinux.org/alpine/edge/testing" >> /etc/apk/repositories
-RUN echo "@community https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
 RUN apk add --no-cache \
     cmake \
     make \
@@ -43,8 +41,8 @@ RUN apk add --no-cache \
     linux-headers \
     boost-dev \
     gmp-dev \
-    cln-dev@testing \
-    ginac-dev@testing \
+    cln-dev \
+    ginac-dev \
     $packages
 
 # Build Carl-storm


### PR DESCRIPTION
Use Docker tag `edge` instead of `latest`.
Packages `cln-dev` and `ginac-dev` are part of `community` now.