### PR TITLE
problem with unused variable 

### DIFF
--- a/src/carl/core/MultivariatePolynomial.tpp
+++ b/src/carl/core/MultivariatePolynomial.tpp
@@ -2150,12 +2150,11 @@ template<typename Coeff, typename Ordering, typename Policies>
 bool MultivariatePolynomial<Coeff, Ordering, Policies>::isConsistent() const {
 	std::set<Monomial::Arg> monomials;
 	for (unsigned i = 0; i < this->mTerms.size(); i++) {
-		//assert(this->mTerms[i]);
 		assert(!this->mTerms[i].isZero());
 		if (i > 0) {
 			assert(this->mTerms[i].tdeg() > 0);
 		}
-		auto it = monomials.insert(mTerms[i].monomial());
+        [[maybe_unused]] auto it = monomials.insert(mTerms[i].monomial());
 		assert(it.second);
 	}
 	if (mOrdered) {


### PR DESCRIPTION
From here: https://github.com/pmc-tools/umb-bservatory/actions/runs/21165219140/job/60868182428

```
#15 80.03 /opt/storm/build/_deps/carl-src/src/carl/core/MultivariatePolynomial.tpp: In instantiation of 'bool carl::MultivariatePolynomial<Coeff, Ordering, Policies>::isConsistent() const [with Coeff = cln::cl_RA; Ordering = carl::NotRelevant; Policies = carl::StdMultivariatePolynomialPolicies<>]':
#15 80.03 /opt/storm/src/storm/adapters/RationalFunctionAdapter.cpp:10:22:   required from here
#15 80.03    10 | template class carl::MultivariatePolynomial<storm::RationalFunctionCoefficient>;
#15 80.03       |                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
#15 80.03 /opt/storm/build/_deps/carl-src/src/carl/core/MultivariatePolynomial.tpp:2158:22: error: variable 'it' set but not used [-Werror=unused-but-set-variable]
#15 80.03  2158 |                 auto it = monomials.insert(mTerms[i].monomial());
#15 80.03
```