### PR TITLE
Sqrt with precision guarantee for GMP

### DIFF
--- a/doc/sqrt_proof.md
+++ b/doc/sqrt_proof.md
@@ -1,0 +1,91 @@
+# Square root proof
+
+Let $\frac{n}{d} > 0$ be a rational number.
+We want to compute $\sqrt{\frac{n}{d}}$.
+The current algorithm will return an interval
+$[\frac{\lfloor{\sqrt{n}\rfloor}}{\lfloor\sqrt{d}\rfloor+1}, \frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}]$ in which the square root lies.
+
+We now want to achieve a given relative precision $\varepsilon > 0$ such that
+$$\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}-\frac{\lfloor\sqrt{n}\rfloor}{\lfloor\sqrt{d}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}$$
+
+To this end, we introduce a constant $x$ and multiply both $n$ and $d$ with this constant.
+As $\frac{nx}{dx}=\frac{n}{d}$ this does not change the result.
+TODO: still changes result!!!
+
+But we can influence the precision by choosing $x$ such that
+$$\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}-\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}$$
+
+
+We propose the following lower bound on $x$ which achieves the desired precision:
+$$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$$
+
+
+## Proof
+We need to ensure:
+$$
+\begin{align}
+&&\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}-\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1} &\leq\varepsilon\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor} \\
+\overset{\text{multiply }\lfloor\sqrt{dx}\rfloor(\lfloor\sqrt{dx}\rfloor+1)}\iff &&(\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1)-\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor &\leq\varepsilon (\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1) \\
+\iff && (\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor+\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1)-\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor & \leq\varepsilon (\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor+\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1)\\
+\iff && \lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1 - \varepsilon (\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1) &\leq \varepsilon \lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor\\
+\iff && (1-\varepsilon)(\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1) &\leq \varepsilon \lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor \\
+\iff && \lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1 &\leq \frac{\varepsilon}{(1-\varepsilon)} \lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor \\
+\iff && \frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor}+\frac{\lfloor\sqrt{dx}\rfloor}{\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
+\iff && \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{nx}\rfloor}+\frac{1}{\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
+\overset{\sqrt{nx}=\sqrt{\frac{n}{d}}\sqrt{dx}}\iff && \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
+\end{align}
+$$
+
+We use the following inequality:
+$$
+\frac{1}{\lfloor\sqrt{nx}\rfloor}
+= \frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}
+\leq \frac{1}{\lfloor\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor\rfloor}
+\leq \frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor - 1}
+$$
+and obtain a more conservative bound for the left-hand side:
+$$
+\begin{align}
+& \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor\lfloor\sqrt{dx}\rfloor} \\
+\leq & \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1}+\frac{1}{(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1)\lfloor\sqrt{dx}\rfloor} \\
+\end{align}
+$$
+
+
+We are therefore interested in the inequality
+$$
+\begin{align}
+&& \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1}+\frac{1}{(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1)\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
+\iff && \sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1 + \lfloor\sqrt{dx}\rfloor + 1 &\leq \frac{\varepsilon}{(1-\varepsilon)} \left(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1\right)\lfloor\sqrt{dx}\rfloor\\
+\iff && 0 &\leq \frac{\varepsilon}{(1-\varepsilon)} \left(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1\right)\lfloor\sqrt{dx}\rfloor - \sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor - \lfloor\sqrt{dx}\rfloor \\
+\iff && 0 &\leq \lfloor\sqrt{dx}\rfloor \left(\frac{\varepsilon}{(1-\varepsilon)} \left(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1\right) - \sqrt{\frac{n}{d}} - 1 \right) \\
+\overset{\lfloor\sqrt{dx}\rfloor\geq0}\implies && 0 &\leq \frac{\varepsilon}{(1-\varepsilon)} \left(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1\right) - \sqrt{\frac{n}{d}} - 1\\
+\iff && \sqrt{\frac{n}{d}} + 1 + \frac{\varepsilon}{(1-\varepsilon)} &\leq \frac{\varepsilon}{(1-\varepsilon)} \sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor \\
+\iff && \frac{1-\varepsilon}{\varepsilon} + \frac{(1-\varepsilon)\sqrt{\frac{d}{n}}}{\varepsilon} + \sqrt{\frac{d}{n}} &\leq \lfloor\sqrt{dx}\rfloor \\
+\implies && \left\lceil\frac{1-\varepsilon}{\varepsilon} + \frac{(1-\varepsilon)\sqrt{\frac{d}{n}}}{\varepsilon} + \sqrt{\frac{d}{n}}\right\rceil &\leq \sqrt{dx} \\
+\iff && \left\lceil\frac{1-\varepsilon}{\varepsilon} + \frac{(1-\varepsilon)\sqrt{\frac{d}{n}}}{\varepsilon} + \sqrt{\frac{d}{n}}\right\rceil^2 \frac{1}{d} &\leq x \\
+\iff && \left\lceil\frac{1-\varepsilon}{\varepsilon} + \sqrt{\frac{d}{n}}(\frac{1}{\varepsilon} -1+1)\right\rceil^2 \frac{1}{d} &\leq x \\
+\iff && \left\lceil\frac{1}{\varepsilon}\left(1+\sqrt{\frac{d}{n}}\right)-1\right\rceil^2 \frac{1}{d} &\leq x \\
+\iff && \left\lceil\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1\right\rceil^2 \frac{1}{d} &\leq x \\
+\end{align}
+$$
+We can again obtain a more conservative bound:
+$$
+\begin{align}
+ &\left\lceil\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1\right\rceil^2 \frac{1}{d} \\
+\leq &\left(\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1+1\right)^2 \frac{1}{d} \\
+= &\frac{1}{d\varepsilon^2}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)^2 \\
+= &\frac{1}{dn\varepsilon^2}\left(n+2\sqrt{nd}+d\right)\\
+\end{align}
+$$
+
+using the the AM–GM inequality $\sqrt{uv} \leq \frac{u+v}{2}$ (for $u,v > 0$).
+$$
+\begin{align}
+&\frac{1}{dn\varepsilon^2}\left(n+2\sqrt{nd}+d\right) \\
+\leq &\frac{1}{dn\varepsilon^2}\left(n+(n+d)+d\right) \\
+= &\frac{1}{\varepsilon^2} \left(\frac{2}{d} + \frac{2}{n}\right) \\
+\end{align}
+$$
+This is the final bound
+$$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$$

--- a/doc/sqrt_proof.md
+++ b/doc/sqrt_proof.md
@@ -1,31 +1,47 @@
 # Square root proof
 
-Let $\frac{n}{d} > 0$ be a rational number.
+## Goal
+Let $\frac{n}{d} > 0$ be a rational number with integers $n,d>0$.
 We want to compute $\sqrt{\frac{n}{d}}$.
+
 The current algorithm will return an interval
 $[\frac{\lfloor{\sqrt{n}\rfloor}}{\lfloor\sqrt{d}\rfloor+1}, \frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}]$ in which the square root lies.
 
+## Relative precision
 We now want to achieve a given relative precision $\varepsilon > 0$ such that
-$$\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}-\frac{\lfloor\sqrt{n}\rfloor}{\lfloor\sqrt{d}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}$$
+$\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}-\frac{\lfloor\sqrt{n}\rfloor}{\lfloor\sqrt{d}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{n}\rfloor+1}{\lfloor\sqrt{d}\rfloor}$
 
-To this end, we introduce a constant $x$ and multiply both $n$ and $d$ with this constant.
-As $\frac{nx}{dx}=\frac{n}{d}$ this does not change the result.
-TODO: still changes result!!!
+To this end, we introduce a scaling factor (integer) $x>0$ and multiply both $n$ and $d$ with this constant.
 
-But we can influence the precision by choosing $x$ such that
-$$\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}-\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}$$
+We then obtain the bounds
+$\sqrt{\frac{nx}{dx}} \in [\frac{\lfloor{\sqrt{nx}\rfloor}}{\lfloor\sqrt{dx}\rfloor+1}, \frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}]$ in which the square root lies.
+
+### Correctness roof
+The bounds are valid lower and upper bounds.
+This can be seen by
+$\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1} \leq \frac{\sqrt{nx}}{\lfloor\sqrt{dx}\rfloor+1} \leq \frac{\sqrt{nx}}{\sqrt{dx}} = \sqrt{\frac{n}{d}}$
+for the lower bound and by
+$\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor} \geq \frac{\lfloor\sqrt{nx}\rfloor+1}{\sqrt{dx}} \geq \frac{\sqrt{nx}}{\sqrt{dx}} = \sqrt{\frac{n}{d}}$
+for the upper bound.
+
+### Precision
+Overall, we can influence the precision by choosing $x$ such that
+$\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}-\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1}\leq\varepsilon\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}$
 
 
+
+## Scaling factor
 We propose the following lower bound on $x$ which achieves the desired precision:
-$$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$$
+$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$
 
 
 ## Proof
+In the remainder, we obtain the bound for $x$ and thereby prove its correctness.
 We need to ensure:
-$$
+$
 \begin{align}
 &&\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor}-\frac{\lfloor\sqrt{nx}\rfloor}{\lfloor\sqrt{dx}\rfloor+1} &\leq\varepsilon\frac{\lfloor\sqrt{nx}\rfloor+1}{\lfloor\sqrt{dx}\rfloor} \\
-\overset{\text{multiply }\lfloor\sqrt{dx}\rfloor(\lfloor\sqrt{dx}\rfloor+1)}\iff &&(\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1)-\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor &\leq\varepsilon (\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1) \\
+\iff &&(\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1)-\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor &\leq\varepsilon (\lfloor\sqrt{nx}\rfloor+1)(\lfloor\sqrt{dx}\rfloor+1) \\
 \iff && (\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor+\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1)-\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor & \leq\varepsilon (\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor+\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1)\\
 \iff && \lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1 - \varepsilon (\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1) &\leq \varepsilon \lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor\\
 \iff && (1-\varepsilon)(\lfloor\sqrt{nx}\rfloor+\lfloor\sqrt{dx}\rfloor+1) &\leq \varepsilon \lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor \\
@@ -34,26 +50,26 @@ $$
 \iff && \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{nx}\rfloor}+\frac{1}{\lfloor\sqrt{nx}\rfloor\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
 \overset{\sqrt{nx}=\sqrt{\frac{n}{d}}\sqrt{dx}}\iff && \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
 \end{align}
-$$
+$
 
 We use the following inequality:
-$$
+$
 \frac{1}{\lfloor\sqrt{nx}\rfloor}
 = \frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}
 \leq \frac{1}{\lfloor\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor\rfloor}
 \leq \frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor - 1}
-$$
+$
 and obtain a more conservative bound for the left-hand side:
-$$
+$
 \begin{align}
 & \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor}+\frac{1}{\lfloor\sqrt{\frac{n}{d}}\sqrt{dx}\rfloor\lfloor\sqrt{dx}\rfloor} \\
 \leq & \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1}+\frac{1}{(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1)\lfloor\sqrt{dx}\rfloor} \\
 \end{align}
-$$
+$
 
 
 We are therefore interested in the inequality
-$$
+$
 \begin{align}
 && \frac{1}{\lfloor\sqrt{dx}\rfloor}+\frac{1}{\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1}+\frac{1}{(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1)\lfloor\sqrt{dx}\rfloor} &\leq \frac{\varepsilon}{(1-\varepsilon)} \\
 \iff && \sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1 + \lfloor\sqrt{dx}\rfloor + 1 &\leq \frac{\varepsilon}{(1-\varepsilon)} \left(\sqrt{\frac{n}{d}}\lfloor\sqrt{dx}\rfloor-1\right)\lfloor\sqrt{dx}\rfloor\\
@@ -68,24 +84,28 @@ $$
 \iff && \left\lceil\frac{1}{\varepsilon}\left(1+\sqrt{\frac{d}{n}}\right)-1\right\rceil^2 \frac{1}{d} &\leq x \\
 \iff && \left\lceil\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1\right\rceil^2 \frac{1}{d} &\leq x \\
 \end{align}
-$$
+$
+
 We can again obtain a more conservative bound:
-$$
+
+$
 \begin{align}
  &\left\lceil\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1\right\rceil^2 \frac{1}{d} \\
 \leq &\left(\frac{1}{\varepsilon}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)-1+1\right)^2 \frac{1}{d} \\
 = &\frac{1}{d\varepsilon^2}\left(\frac{\sqrt{n}+\sqrt{d}}{\sqrt{n}}\right)^2 \\
 = &\frac{1}{dn\varepsilon^2}\left(n+2\sqrt{nd}+d\right)\\
 \end{align}
-$$
+$
 
-using the the AM–GM inequality $\sqrt{uv} \leq \frac{u+v}{2}$ (for $u,v > 0$).
-$$
+Using the AM–GM inequality $\sqrt{uv} \leq \frac{u+v}{2}$ (for $u,v > 0$) we can further simplify.
+
+$
 \begin{align}
 &\frac{1}{dn\varepsilon^2}\left(n+2\sqrt{nd}+d\right) \\
 \leq &\frac{1}{dn\varepsilon^2}\left(n+(n+d)+d\right) \\
 = &\frac{1}{\varepsilon^2} \left(\frac{2}{d} + \frac{2}{n}\right) \\
 \end{align}
-$$
+$
+
 This is the final bound
-$$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$$
+$ x \geq \frac{2}{\varepsilon^2} \left(\frac{1}{d} + \frac{1}{n}\right)$.

--- a/src/carl/numbers/adaption_cln/operations.cpp
+++ b/src/carl/numbers/adaption_cln/operations.cpp
@@ -122,6 +122,7 @@ std::pair<cln::cl_RA, cln::cl_RA> sqrt_precision(const cln::cl_RA& a, const cln:
 
     // Precision was not achieved
     // -> Manually scale numerator and denominator
+    // see doc/sqrt_proof.md for details on the scaling factor.
     cln::cl_I num = cln::numerator(a);
     cln::cl_I den = cln::denominator(a);
     assert(num >= 1);

--- a/src/carl/numbers/adaption_cln/operations.cpp
+++ b/src/carl/numbers/adaption_cln/operations.cpp
@@ -74,6 +74,29 @@ cln::cl_RA scaleByPowerOfTwo(const cln::cl_RA& a, int exp) {
     return a;
 }
 
+std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_I& num, const cln::cl_I& den) {
+    // Compute square roots for numerator and denominator individually
+    cln::cl_I root_num;
+    cln::cl_I root_den;
+    bool num_perfect_square = cln::isqrt(num, &root_num);
+    bool den_perfect_square = cln::isqrt(den, &root_den);
+
+    cln::cl_I lower = root_num;
+    if (den_perfect_square)
+        lower /= root_den;
+    else
+        lower /= root_den + 1;
+
+    cln::cl_I upper;
+    if (num_perfect_square)
+        upper = root_num;
+    else
+        upper = root_num + 1;
+    upper /= root_den;
+
+    return std::make_pair(lower, upper);
+}
+
 std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_RA& a) {
     assert(a >= 0);
     cln::cl_RA exact_root;
@@ -81,34 +104,33 @@ std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_RA& a) {
         // root can be computed exactly.
         return std::make_pair(exact_root, exact_root);
     } else {
-        auto factor = int(cln::integer_length(cln::denominator(a))) - int(cln::integer_length(cln::numerator(a)));
-        if (cln::oddp(factor))
-            factor += 1;
-        cln::cl_RA n = scaleByPowerOfTwo(a, factor);
-        double dn = toDouble(n);
-        cln::cl_RA nra = cln::rationalize(dn);
-        boost::numeric::interval<double> i;
-        if (nra > n) {
-            i.assign(toDouble(2 * n - nra), dn);
-            assert(2 * n - nra <= n);
-        } else {
-            i.assign(dn, toDouble(2 * n - nra));
-            assert(n <= 2 * n - nra);
-        }
-        i = boost::numeric::sqrt(i);
-        i.assign(std::nexttoward(i.lower(), -std::numeric_limits<double>::infinity()), std::nexttoward(i.upper(), std::numeric_limits<double>::infinity()));
-        factor = factor / 2;
-        cln::cl_RA lower = scaleByPowerOfTwo(cln::rationalize(i.lower()), -factor);
-        cln::cl_RA upper = scaleByPowerOfTwo(cln::rationalize(i.upper()), -factor);
-        assert(lower * lower <= a);
-        assert(a <= upper * upper);
-        return std::make_pair(lower, upper);
+        return sqrt_safe(cln::numerator(a), cln::denominator(a));
     }
 }
 
 std::pair<cln::cl_RA, cln::cl_RA> sqrt_precision(const cln::cl_RA& a, const cln::cl_RA& prec) {
-    // Precision should already be achieved through use of sqrt and cln::rationalize
+    assert(a >= 0);
+    assert(prec > 0);
+    assert(prec < 1);
+
+    // Start with sqrt_safe
     auto res = sqrt_safe(a);
+    if (res.second - res.first <= prec * res.second) {
+        // Precision was achieved
+        return res;
+    }
+
+    // Precision was not achieved
+    // -> Manually scale numerator and denominator
+    cln::cl_I num = cln::numerator(a);
+    cln::cl_I den = cln::denominator(a);
+    assert(num >= 1);
+    assert(den >= 1);
+    // Scale with 2/precision^2 (1/numerator + 1/denominator)
+    cln::cl_RA scale = cln::cl_RA(2) * (cln::cl_RA(1) / num + cln::cl_RA(1) / den) / pow(prec, 2);
+    assert(ceil(scale) > 1);
+    // Compute sqrt once again but with scaled numbers
+    res = sqrt_safe(num * ceil(scale), den * ceil(scale));
     assert(res.second - res.first <= prec * res.second);
     return res;
 }

--- a/src/carl/numbers/adaption_cln/operations.cpp
+++ b/src/carl/numbers/adaption_cln/operations.cpp
@@ -109,7 +109,7 @@ std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_RA& a) {
 std::pair<cln::cl_RA, cln::cl_RA> sqrt_precision(const cln::cl_RA& a, const cln::cl_RA& prec) {
     // Precision should already be achieved through use of sqrt and cln::rationalize
     auto res = sqrt_safe(a);
-    assert(res.second - res.first <= prec);
+    assert(res.second - res.first <= prec * res.second);
     return res;
 }
 

--- a/src/carl/numbers/adaption_cln/operations.cpp
+++ b/src/carl/numbers/adaption_cln/operations.cpp
@@ -106,6 +106,13 @@ std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_RA& a) {
     }
 }
 
+std::pair<cln::cl_RA, cln::cl_RA> sqrt_precision(const cln::cl_RA& a, const cln::cl_RA& prec) {
+    // Precision should already be achieved through use of sqrt and cln::rationalize
+    auto res = sqrt_safe(a);
+    assert(res.second - res.first <= prec);
+    return res;
+}
+
 std::pair<cln::cl_RA, cln::cl_RA> sqrt_fast(const cln::cl_RA& a) {
     assert(a >= 0);
     cln::cl_RA exact_root;

--- a/src/carl/numbers/adaption_cln/operations.h
+++ b/src/carl/numbers/adaption_cln/operations.h
@@ -434,6 +434,11 @@ cln::cl_RA sqrt(const cln::cl_RA& a);
 std::pair<cln::cl_RA, cln::cl_RA> sqrt_safe(const cln::cl_RA& a);
 
 /**
+ * Calculate the square root of fraction such that the resulting upper and lower bounds have at most prec difference.
+ */
+std::pair<cln::cl_RA, cln::cl_RA> sqrt_precision(const cln::cl_RA& a, const cln::cl_RA& prec);
+
+/**
  * Compute square root in a fast but less precise way.
  * Use cln::sqrt() to obtain an approximation. If the result is rational, i.e. the result is exact, use this result.
  * Otherwise use the nearest integers as bounds on the square root.

--- a/src/carl/numbers/adaption_gmpxx/operations.cpp
+++ b/src/carl/numbers/adaption_gmpxx/operations.cpp
@@ -35,17 +35,14 @@ mpq_class sqrt(const mpq_class& a) {
     return (r.first + r.second) / 2;
 }
 
-std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a) {
-    assert(mpq_sgn(a.__get_mp()) > 0);
-    mpz_class den = a.get_den();
-    mpz_class num = a.get_num();
-    mpz_class root_den;
-    mpz_class root_den_rem;
-    mpz_sqrtrem(root_den.__get_mp(), root_den_rem.__get_mp(), den.__get_mp());
-
+std::pair<mpq_class, mpq_class> sqrt_safe(const mpz_class& num, const mpz_class& den) {
     mpz_class root_num;
     mpz_class root_num_rem;
     mpz_sqrtrem(root_num.__get_mp(), root_num_rem.__get_mp(), num.__get_mp());
+
+    mpz_class root_den;
+    mpz_class root_den_rem;
+    mpz_sqrtrem(root_den.__get_mp(), root_den_rem.__get_mp(), den.__get_mp());
 
     mpq_class lower;
     mpq_class upper;
@@ -64,6 +61,19 @@ std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a) {
     upper /= root_den;
 
     return std::make_pair(lower, upper);
+}
+
+std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a) {
+    assert(mpq_sgn(a.__get_mp()) > 0);
+    return sqrt_safe(a.get_num(), a.get_den());
+}
+
+std::pair<mpq_class, mpq_class> sqrt_precision(const mpq_class& a, const mpq_class& prec) {
+    assert(mpq_sgn(a.__get_mp()) > 0);
+    mpq_class scale = 2 / (prec * prec);
+    auto res = sqrt_safe(a.get_num() * scale.get_num(), a.get_den() * scale.get_num());
+    assert(res.second - res.first <= prec);
+    return res;
 }
 
 std::pair<mpq_class, mpq_class> root_safe(const mpq_class& a, uint n) {

--- a/src/carl/numbers/adaption_gmpxx/operations.cpp
+++ b/src/carl/numbers/adaption_gmpxx/operations.cpp
@@ -70,14 +70,27 @@ std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a) {
 
 std::pair<mpq_class, mpq_class> sqrt_precision(const mpq_class& a, const mpq_class& prec) {
     assert(mpq_sgn(a.__get_mp()) > 0);
-    // Scale such that scale*max(num, denom) >= 2/precision^2
-    // Then the resulting interval has width <= precision
-    mpq_class scale = 2 / (prec * prec);
-    scale /= a.get_num() > a.get_den() ? a.get_num() : a.get_den();
-    if (scale < 1) {
-        scale = 1;
+    assert(prec > 0);
+    assert(prec < 1);
+
+    // Start with sqrt_safe
+    auto res = sqrt_safe(a);
+    if (res.second - res.first <= prec * res.second) {
+        // Precision was achieved
+        return res;
     }
-    auto res = sqrt_safe(a.get_num() * scale.get_num(), a.get_den() * scale.get_num());
+
+    // Precision was not achieved
+    // -> Manually scale numerator and denominator
+    mpz_class num = a.get_num();
+    mpz_class den = a.get_den();
+    assert(num >= 1);
+    assert(den >= 1);
+    // Scale with 2/precision^2 (1/numerator + 1/denominator)
+    mpq_class scale = mpq_class(2) * (mpq_class(1) / num + mpq_class(1) / den) / pow(prec, 2);
+    assert(ceil(scale) > 1);
+    // Compute sqrt once again but with scaled numbers
+    res = sqrt_safe(num * ceil(scale), den * ceil(scale));
     assert(res.second - res.first <= prec * res.second);
     return res;
 }

--- a/src/carl/numbers/adaption_gmpxx/operations.cpp
+++ b/src/carl/numbers/adaption_gmpxx/operations.cpp
@@ -70,9 +70,15 @@ std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a) {
 
 std::pair<mpq_class, mpq_class> sqrt_precision(const mpq_class& a, const mpq_class& prec) {
     assert(mpq_sgn(a.__get_mp()) > 0);
+    // Scale such that scale*max(num, denom) >= 2/precision^2
+    // Then the resulting interval has width <= precision
     mpq_class scale = 2 / (prec * prec);
+    scale /= a.get_num() > a.get_den() ? a.get_num() : a.get_den();
+    if (scale < 1) {
+        scale = 1;
+    }
     auto res = sqrt_safe(a.get_num() * scale.get_num(), a.get_den() * scale.get_num());
-    assert(res.second - res.first <= prec);
+    assert(res.second - res.first <= prec * res.second);
     return res;
 }
 

--- a/src/carl/numbers/adaption_gmpxx/operations.cpp
+++ b/src/carl/numbers/adaption_gmpxx/operations.cpp
@@ -82,6 +82,7 @@ std::pair<mpq_class, mpq_class> sqrt_precision(const mpq_class& a, const mpq_cla
 
     // Precision was not achieved
     // -> Manually scale numerator and denominator
+    // see doc/sqrt_proof.md for details on the scaling factor.
     mpz_class num = a.get_num();
     mpz_class den = a.get_den();
     assert(num >= 1);

--- a/src/carl/numbers/adaption_gmpxx/operations.h
+++ b/src/carl/numbers/adaption_gmpxx/operations.h
@@ -421,6 +421,11 @@ mpq_class sqrt(const mpq_class& a);
 std::pair<mpq_class, mpq_class> sqrt_safe(const mpq_class& a);
 
 /**
+ * Calculate the square root of fraction such that the resulting upper and lower bounds have at most prec difference.
+ */
+std::pair<mpq_class, mpq_class> sqrt_precision(const mpq_class& a, const mpq_class& prec);
+
+/**
  * Calculate the nth root of a fraction.
  * The precise result is contained in the resulting interval.
  */

--- a/src/tests/numbers/Test_numbers.cpp
+++ b/src/tests/numbers/Test_numbers.cpp
@@ -104,9 +104,34 @@ TYPED_TEST(RationalNumbers, Squareroot) {
     }
     {
         TypeParam a = TypeParam("93536104789177766012087302264675950042191285291185") / TypeParam("93536104789177786765035829293842113257979682750464");
-        std::pair<TypeParam, TypeParam> resultA = carl::sqrt_safe(a);
-        EXPECT_LE(resultA.first * resultA.first, a);
-        EXPECT_LE(a, resultA.second * resultA.second);
+        std::pair<TypeParam, TypeParam> res = carl::sqrt_safe(a);
+        EXPECT_LE(res.first * res.first, a);
+        EXPECT_LE(a, res.second * res.second);
+    }
+}
+
+TYPED_TEST(RationalNumbers, Sqrt_precision) {
+    TypeParam precision = TypeParam(1) / TypeParam(100000);
+    {
+        TypeParam a = TypeParam(2);
+        std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
+        EXPECT_LE(res.first * res.first, a);
+        EXPECT_LE(a, res.second * res.second);
+        EXPECT_LE(res.second - res.first, precision);
+    }
+    {
+        TypeParam a = TypeParam(2) / TypeParam(3);
+        std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
+        EXPECT_LE(res.first * res.first, a);
+        EXPECT_LE(a, res.second * res.second);
+        EXPECT_LE(res.second - res.first, precision);
+    }
+    {
+        TypeParam a = TypeParam("93536104789177766012087302264675950042191285291185") / TypeParam("93536104789177786765035829293842113257979682750464");
+        std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
+        EXPECT_LE(res.first * res.first, a);
+        EXPECT_LE(a, res.second * res.second);
+        EXPECT_LE(res.second - res.first, precision);
     }
 }
 

--- a/src/tests/numbers/Test_numbers.cpp
+++ b/src/tests/numbers/Test_numbers.cpp
@@ -117,21 +117,28 @@ TYPED_TEST(RationalNumbers, Sqrt_precision) {
         std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
         EXPECT_LE(res.first * res.first, a);
         EXPECT_LE(a, res.second * res.second);
-        EXPECT_LE(res.second - res.first, precision);
+        EXPECT_LE(res.second - res.first, precision * res.second);
     }
     {
         TypeParam a = TypeParam(2) / TypeParam(3);
         std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
         EXPECT_LE(res.first * res.first, a);
         EXPECT_LE(a, res.second * res.second);
-        EXPECT_LE(res.second - res.first, precision);
+        EXPECT_LE(res.second - res.first, precision * res.second);
     }
     {
         TypeParam a = TypeParam("93536104789177766012087302264675950042191285291185") / TypeParam("93536104789177786765035829293842113257979682750464");
         std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
         EXPECT_LE(res.first * res.first, a);
         EXPECT_LE(a, res.second * res.second);
-        EXPECT_LE(res.second - res.first, precision);
+        EXPECT_LE(res.second - res.first, precision * res.second);
+    }
+    {
+        TypeParam a = TypeParam("93536104789177766012087302264675950042191285291185");
+        std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
+        EXPECT_LE(res.first * res.first, a);
+        EXPECT_LE(a, res.second * res.second);
+        EXPECT_LE(res.second - res.first, precision * res.second);
     }
 }
 

--- a/src/tests/numbers/Test_numbers.cpp
+++ b/src/tests/numbers/Test_numbers.cpp
@@ -140,6 +140,36 @@ TYPED_TEST(RationalNumbers, Sqrt_precision) {
         EXPECT_LE(a, res.second * res.second);
         EXPECT_LE(res.second - res.first, precision * res.second);
     }
+    {
+        // Perform randomized tests
+        const size_t runs = 1000000;
+        std::srand(std::time({}));  // use current time as seed for random generator
+        for (size_t i = 0; i < runs; ++i) {
+            TypeParam num = TypeParam(std::rand()) * RAND_MAX + TypeParam(std::rand());
+            TypeParam denom = TypeParam(std::rand()) * RAND_MAX + TypeParam(std::rand());
+            TypeParam precision = TypeParam(1) / TypeParam(std::rand() + 1 % 1000000000);
+            TypeParam a = num / denom;
+            std::pair<TypeParam, TypeParam> res = carl::sqrt_precision(a, precision);
+            EXPECT_LE(res.first * res.first, a);
+            EXPECT_LE(a, res.second * res.second);
+            EXPECT_LE(res.second - res.first, precision * res.second);
+        }
+        for (size_t i = 0; i < runs; ++i) {
+            TypeParam num = TypeParam(std::rand());
+            TypeParam denom = TypeParam(1);
+            TypeParam precision = TypeParam(1) / TypeParam(std::rand() + 1 % 1000000000);
+            TypeParam a = num / denom;
+            TypeParam b = denom / num;
+            std::pair<TypeParam, TypeParam> resA = carl::sqrt_precision(a, precision);
+            std::pair<TypeParam, TypeParam> resB = carl::sqrt_precision(b, precision);
+            EXPECT_LE(resA.first * resA.first, a);
+            EXPECT_LE(a, resA.second * resA.second);
+            EXPECT_LE(resA.second - resA.first, precision * resA.second);
+            EXPECT_LE(resB.first * resB.first, b);
+            EXPECT_LE(b, resB.second * resB.second);
+            EXPECT_LE(resB.second - resB.first, precision * resB.second);
+        }
+    }
 }
 
 TYPED_TEST(RationalNumbers, Sqrt_fast) {


### PR DESCRIPTION
Added functions `sqrt_precision` to compute sqrt with given precision.
For CLN, the use of `rationalize` should already ensure the precision.
For GMP, we scale both numerator and denominator to achieve the precision.

Fixes https://github.com/moves-rwth/storm/issues/873