### PR TITLE
Do not set absolute installation path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,13 +197,6 @@ endif()
 message(STATUS "carl - Build type: ${CMAKE_BUILD_TYPE}")
 
 
-foreach(p LIB BIN INCLUDE CMAKE)
-  set(var CARL_${p}_INSTALL_DIR)
-  if(NOT IS_ABSOLUTE "${${var}}")
-    set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
-  endif()
-endforeach()
-
 # path to put in the executables after building.
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin CACHE PATH "Directory for built executables")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,6 +197,16 @@ endif()
 message(STATUS "carl - Build type: ${CMAKE_BUILD_TYPE}")
 
 
+if(PROJECT_IS_TOP_LEVEL)
+  foreach(p LIB BIN INCLUDE CMAKE)
+    set(var CARL_${p}_INSTALL_DIR)
+    if(NOT IS_ABSOLUTE "${${var}}")
+      set(${var} "${CMAKE_INSTALL_PREFIX}/${${var}}")
+    endif()
+  endforeach()
+endif()
+
+
 # path to put in the executables after building.
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin CACHE PATH "Directory for built executables")
 


### PR DESCRIPTION
This led to carl being installed into a different directory than the rest of Storm.
This fixes one of the issues in https://github.com/stormchecker/storm/pull/732