### PR TITLE
Ignore some recent compiler warnings

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -39,11 +39,11 @@ jobs:
              packages: "clang",
              distro: "archlinux"
             }
-          - { name: "muslc",
-              build_type: "Debug",
-              cmake_args: "-DCARL_WARNING_AS_ERROR=ON",
-              packages: "",
-              distro: "alpine"
+          - {name: "musl",
+             build_type: "Debug",
+             cmake_args: "-DCARL_WARNING_AS_ERROR=ON",
+             packages: "",
+             distro: "alpine"
             }
     steps:
       - name: Git clone
@@ -102,24 +102,24 @@ jobs:
     strategy:
       matrix:
         config:
-          - {name: "XCode 15.4, ARM",
+          - {name: "MacOS 14, ARM",
              distro: "macos-14",
              xcode: "15.4",
              build_type: "Debug"
             }
-          - {name: "XCode Latest, ARM",
+          - {name: "MacOS 15, ARM",
              distro: "macos-15",
-             xcode: "latest-stable",
+             xcode: "16.4",
              build_type: "Debug"
             }
-          - {name: "XCode Latest, Intel",
-             distro: "macos-15-intel",
-             xcode: "latest-stable",
-             build_type: "Debug"
-            }
-          - {name: "XCode 26, ARM",
+          - {name: "MacOS 26, ARM",
              distro: "macos-26",
-             xcode: "26",
+             xcode: "latest-stable",
+             build_type: "Debug"
+            }
+          - {name: "MacOS 26, Intel",
+             distro: "macos-26-intel",
+             xcode: "latest-stable",
              build_type: "Debug"
             }
     runs-on: ${{ matrix.config.distro }}

--- a/src/carl/formula/parser/OPBImporter.cpp
+++ b/src/carl/formula/parser/OPBImporter.cpp
@@ -8,7 +8,7 @@
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/fusion/adapted/std_tuple.hpp>
 #include <boost/fusion/include/std_pair.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_parse.hpp>
 #include <boost/spirit/include/support_line_pos_iterator.hpp>

--- a/src/carl/formula/parser/OPBImporter.cpp
+++ b/src/carl/formula/parser/OPBImporter.cpp
@@ -6,12 +6,14 @@
 #include <vector>
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
+CLANG_WARNING_DISABLE("-Wdeprecated-declarations")
 #include <boost/fusion/adapted/std_tuple.hpp>
 #include <boost/fusion/include/std_pair.hpp>
 #include <boost/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_parse.hpp>
 #include <boost/spirit/include/support_line_pos_iterator.hpp>
+CLANG_WARNING_RESET
 
 namespace carl {
 	namespace spirit = boost::spirit;

--- a/src/carl/formula/parser/SpiritHelper.h
+++ b/src/carl/formula/parser/SpiritHelper.h
@@ -3,8 +3,10 @@
 #include "../../util/SFINAE.h"
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
+CLANG_WARNING_DISABLE("-Wdeprecated-declarations")
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/support_line_pos_iterator.hpp>
+CLANG_WARNING_RESET
 
 namespace carl {
 namespace parser {

--- a/src/carl/numbers/adaption_gmpxx/include.h
+++ b/src/carl/numbers/adaption_gmpxx/include.h
@@ -5,4 +5,19 @@ static_assert(false, "This file may only be included indirectly by numbers.h");
 #endif
 
 #include <cstddef>
+
+// Disable potential warning on newer AppleClang versions
+#if __GNUC__ && defined( __has_warning )
+#if __has_warning("-Wdeprecated-literal-operator")
+#define SUPPRESSING
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-literal-operator"
+#endif
+#endif
+
 #include <gmpxx.h>
+
+#ifdef SUPPRESSING
+#undef SUPPRESSING
+#pragma GCC diagnostic pop
+#endif

--- a/src/carl/numbers/parser/parser.h
+++ b/src/carl/numbers/parser/parser.h
@@ -3,11 +3,13 @@
 #include <boost/optional.hpp>
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
+CLANG_WARNING_DISABLE("-Wdeprecated-declarations")
 #include <boost/phoenix/bind.hpp>
 #include <boost/phoenix/core.hpp>
 #include <boost/phoenix/operator.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/qi_parse.hpp>
+CLANG_WARNING_RESET
 
 #include "../typetraits.h"
 

--- a/src/carl/util/parser/Common.h
+++ b/src/carl/util/parser/Common.h
@@ -9,8 +9,10 @@
 #include <vector>
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
+CLANG_WARNING_DISABLE("-Wdeprecated-declarations")
 #include <boost/spirit/include/qi.hpp>
 #include <boost/phoenix.hpp>
+CLANG_WARNING_RESET
 
 #include "../../formula/Formula.h"
 #include "../../core/MonomialPool.h"

--- a/src/carl/util/parser/Common.h
+++ b/src/carl/util/parser/Common.h
@@ -10,7 +10,7 @@
 
 #define BOOST_SPIRIT_USE_PHOENIX_V3
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 
 #include "../../formula/Formula.h"
 #include "../../core/MonomialPool.h"


### PR DESCRIPTION
- Ignore compiler warning in gmpxx:
```
In file included from /Users/runner/work/carl-storm/carl-storm/src/carl/core/../util/../numbers/adaption_gmpxx/include.h:8:
/usr/local/include/gmpxx.h:2163:29: error: identifier '_mpz' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 2163 | inline mpz_class operator"" _mpz(const char* s)
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_mpz
/usr/local/include/gmpxx.h:2168:29: error: identifier '_mpq' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 2168 | inline mpq_class operator"" _mpq(const char* s)
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_mpq
/usr/local/include/gmpxx.h:2175:29: error: identifier '_mpf' preceded by whitespace in a literal operator declaration is deprecated [-Werror,-Wdeprecated-literal-operator]
 2175 | inline mpf_class operator"" _mpf(const char* s)
      |                  ~~~~~~~~~~~^~~~
      |                  operator""_mpf
```
Ignoring this warning follows the approach from [this Stackoverflow answer](https://stackoverflow.com/questions/42979987/use-pragma-to-disable-a-warning-if-implemented/42979988#42979988) because the warning is only recognized by newer compilers.

- ignore compiler warning in boost spirit:
```
n file included from /Applications/Xcode_26.4_Release_Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/string:602:
/Applications/Xcode_26.4_Release_Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:45:41: error: 'char_traits<unsigned int>' is deprecated: char_traits<T> for T not equal to char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. It will be removed in a future release, so please migrate off of it. [-Werror,-Wdeprecated-declarations]
   45 | template <class _CharT, class _Traits = char_traits<_CharT>, class _Allocator = allocator<_CharT> >
      |                                         ^
/usr/local/include/boost/spirit/home/support/utf8.hpp:24:18: note: in instantiation of default argument for 'basic_string<ucs4_char>' required here
   24 |     typedef std::basic_string<ucs4_char> ucs4_string;
      |                  ^~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode_26.4_Release_Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/string.h:24:8: note: 'char_traits<unsigned int>' has been explicitly marked deprecated here
   24 | struct _LIBCPP_DEPRECATED_(
      |        ^
/Applications/Xcode_26.4_Release_Candidate.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__config:555:53: note: expanded from macro '_LIBCPP_DEPRECATED_'
  555 | #      define _LIBCPP_DEPRECATED_(m) __attribute__((__deprecated__(m)))
      |               
```
- also fixed another warning by using the newer include `<boost/phoenix.hpp>`