### PR TITLE
Made function static to fix compile warning

### DIFF
--- a/src/carl/formula/model/ran/RealAlgebraicNumber_Interval.h
+++ b/src/carl/formula/model/ran/RealAlgebraicNumber_Interval.h
@@ -22,7 +22,7 @@ struct IntervalContent {
     std::list<Polynomial> sturmSequence;
     std::size_t refinementCount;
 
-    Polynomial replaceVariable(const Polynomial& p) const {
+    static Polynomial replaceVariable(const Polynomial& p) {
         return p.replaceVariable(auxVariable);
     }
 


### PR DESCRIPTION
Fixes compiler warning in latest GCC.

```
/opt/storm/build/_deps/carl-src/src/carl/core/rootfinder/../../formula/model/ran/RealAlgebraicNumber_Interval.h: In constructor ‘carl::ran::IntervalContent<Number>::IntervalContent(const Polynomial&, carl::Interval<Number>) [with Number = cln::cl_RA]’:
/opt/storm/build/_deps/carl-src/src/carl/core/rootfinder/../../formula/model/ran/RealAlgebraicNumber_Interval.h:30:11: error: ‘<unknown>’ may be used uninitialized [-Werror=maybe-uninitialized]
30 |         : polynomial(replaceVariable(p)), interval(i), sturmSequence(p.standardSturmSequence()), refinementCount(0) {}
     |           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```