### PR TITLE
Require CMake >=3.25

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,7 @@
 # G. CPack
 # # # # # # # # # # # # # # # # # # # # # #
 
-cmake_minimum_required (VERSION 3.22)
-
-if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24")
-	cmake_policy(SET CMP0135 NEW) # Use timestamps from time of extraction
-endif()
+cmake_minimum_required (VERSION 3.25)
 
 set(CMAKE_CXX_STANDARD 20)
 


### PR DESCRIPTION
The oldest supported OS is Debian 12 which ships with CMake 3.25.